### PR TITLE
Remove duplicate PhDs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ scoupus_api_key.csv
 # VS Code & dev files
 settings.json
 **/__pycache__/
+.test-artifacts/
 
 # folder with some tests to keep locally
 experimentation

--- a/Open_Alex_Match.py
+++ b/Open_Alex_Match.py
@@ -17,7 +17,7 @@
 from pyalex import config # to set email_address
 import pandas as pd
 from sentence_transformers import SentenceTransformer
-from os import path
+from os import environ, path
 import matplotlib.pyplot as plt
 import sys
 from tqdm import tqdm
@@ -110,7 +110,8 @@ else:
 
 # %%
 # Read configuration, including information on which subset of the data to use
-data_config = read_config('dataset_config.yaml')
+data_config_path = environ.get("OPENALEX_DATASET_CONFIG", "dataset_config.yaml")
+data_config = read_config(data_config_path)
 
 # Get the file name for the output file
 output_filename = data_config['output_filename'] or None

--- a/Open_Alex_Match.py
+++ b/Open_Alex_Match.py
@@ -23,7 +23,12 @@ import sys
 from tqdm import tqdm
 
 from src.unabbreviate_institutions import unabbreviate_institutions
-from src.open_alex_helpers import AuthorRelations, find_phd_and_supervisors_in_row, get_supervisors_openalex_ids
+from src.open_alex_helpers import (
+    AuthorRelations,
+    find_phd_and_supervisors_in_row,
+    get_supervisors_openalex_ids,
+    remove_duplicate_phd_candidates
+)
 from src.dataset_config_helpers import read_config, load_dataset
 from src.api_cache_helpers import initialize_request_cache
 from src.plotters import PhDMatchPlotter, ContributorMatchPlotter
@@ -189,17 +194,17 @@ extraction_series = pubs_high_contrib_df.progress_apply(
 # Concatenate all DataFrames into one
 extraction_df = pd.concat(list(extraction_series), ignore_index=True)
 
-extraction_df.to_csv(output_filename, index=False)
-
 extraction_df
 
 # %% [markdown]
 # ### Handle duplicate PhDs
 
 # %%
-dups = extraction_df[extraction_df.duplicated(subset=['phd_id'], keep=False)].sort_values(by='phd_name')
+extraction_df = remove_duplicate_phd_candidates(extraction_df)
 
-dups
+extraction_df.to_csv(output_filename, index=False)
+
+extraction_df
 
 # %% [markdown]
 # ## 4. Analysis and Visualization

--- a/src/open_alex_helpers.py
+++ b/src/open_alex_helpers.py
@@ -632,6 +632,7 @@ class AuthorRelations:
             'phd_id', 
             'phd_orcid',
             'n_name_search_matches',
+            'duplicate_phds',
             'year', 
             'title', 
             'title_open_alex', 
@@ -693,6 +694,7 @@ class AuthorRelations:
                 'phd_id': phd_id,
                 'phd_orcid': phd_orcid,
                 'n_name_search_matches': self.n_name_search_matches,
+                'duplicate_phds': None,
                 'year': self.year,
                 'title': self.title,
                 'title_open_alex': title_open_alex,
@@ -857,6 +859,69 @@ def compute_and_sort_works_by_title_similarities(works: pd.DataFrame, reference_
     works = works.sort_values("similarity", ascending=False)
     
     return works
+
+
+def remove_duplicate_phd_candidates(extraction_df: pd.DataFrame) -> pd.DataFrame:
+    """
+    Remove duplicate PhD candidates with different integer IDs.
+
+    Prefer ORCIDs for identifying candidates and use OpenAlex IDs when no ORCID
+    is available. For duplicates, keep the integer ID with the most confirmed
+    contributors. Ties are resolved by keeping the first integer ID. Add all
+    duplicate PhD names and OpenAlex IDs to the retained candidate for diagnostics.
+    """
+    candidates = (
+        extraction_df.drop_duplicates(subset="integer_id").copy().reset_index(drop=True)
+    )
+    candidates["duplicate_id"] = (
+        candidates["phd_orcid"].replace("", pd.NA).fillna(candidates["phd_id"])
+    )
+    candidates["n_confirmed_contributors"] = candidates["integer_id"].map(
+        extraction_df.groupby("integer_id", sort=False)["contributor_confirmed"].sum()
+    )
+
+    candidates_with_id = candidates[candidates["duplicate_id"].notna()]
+    duplicate_integer_ids = []
+    duplicate_phds_by_integer_id = {}
+
+    for _, duplicate_candidates in candidates_with_id.groupby("duplicate_id", sort=False):
+        if len(duplicate_candidates) == 1:
+            continue
+
+        kept_index = duplicate_candidates["n_confirmed_contributors"].idxmax()
+        kept_candidate = duplicate_candidates.loc[[kept_index]]
+        removed_candidates = duplicate_candidates.drop(index=kept_index)
+        ordered_candidates = pd.concat([kept_candidate, removed_candidates])
+        kept_integer_id = kept_candidate["integer_id"].iloc[0]
+
+        duplicate_integer_ids.extend(removed_candidates["integer_id"])
+        duplicate_phds_by_integer_id[kept_integer_id] = (
+            ordered_candidates[["phd_name", "phd_id"]].to_dict("records")
+        )
+
+    result = extraction_df[
+        ~extraction_df["integer_id"].isin(duplicate_integer_ids)
+    ].copy()
+    duplicate_phds = pd.Series(
+        [
+            duplicate_phds_by_integer_id.get(integer_id)
+            for integer_id in result["integer_id"]
+        ],
+        index=result.index,
+        dtype=object
+    )
+
+    if "duplicate_phds" in result.columns:
+        result["duplicate_phds"] = duplicate_phds
+    else:
+        column_index = (
+            result.columns.get_loc("n_name_search_matches") + 1
+            if "n_name_search_matches" in result.columns
+            else len(result.columns)
+        )
+        result.insert(column_index, "duplicate_phds", duplicate_phds)
+
+    return result
 
 
 def find_phd_and_supervisors_in_row(row, model):

--- a/src/open_alex_helpers.py
+++ b/src/open_alex_helpers.py
@@ -1071,10 +1071,19 @@ def remove_duplicate_phd_candidates(extraction_df: pd.DataFrame) -> pd.DataFrame
         )
         result.insert(column_index, "duplicate_phds", duplicate_phds)
 
+    n_removed_candidates = len(duplicate_integer_ids)
+    candidate_label = "candidate" if n_removed_candidates == 1 else "candidates"
+    print(f"Removed {n_removed_candidates} duplicate PhD {candidate_label}.")
+
     return result
 
 
-def find_phd_and_supervisors_in_row(row, model):
+def find_phd_and_supervisors_in_row(
+    row,
+    model,
+    row_number=None,
+    total_rows=None,
+):
     """
     Finds author relations information from a DataFrame row.
 
@@ -1083,6 +1092,9 @@ def find_phd_and_supervisors_in_row(row, model):
 
     Parameters:
         row (pd.Series): A row from the DataFrame containing publication data.
+        model: The model used to validate author matches.
+        row_number (int, optional): The one-based position of the active row.
+        total_rows (int, optional): The total number of rows being processed.
 
     Returns:
         pd.DataFrame: A DataFrame with columns as specified.

--- a/tests/test_open_alex_helpers.py
+++ b/tests/test_open_alex_helpers.py
@@ -1,0 +1,75 @@
+import unittest
+
+import pandas as pd
+
+from src.open_alex_helpers import remove_duplicate_phd_candidates
+
+
+class RemoveDuplicatePhdCandidatesTests(unittest.TestCase):
+    def test_keeps_most_confirmed_contributors(self):
+        extraction_df = pd.DataFrame([
+            {"integer_id": 1, "phd_name": "One", "phd_id": "A1", "phd_orcid": "O1", "n_name_search_matches": 1, "contributor_confirmed": True},
+            {"integer_id": 2, "phd_name": "Two", "phd_id": "A2", "phd_orcid": "O1", "n_name_search_matches": 1, "contributor_confirmed": True},
+            {"integer_id": 2, "phd_name": "Two", "phd_id": "A2", "phd_orcid": "O1", "n_name_search_matches": 1, "contributor_confirmed": True},
+            {"integer_id": 3, "phd_name": "Three", "phd_id": "A3", "phd_orcid": "O1", "n_name_search_matches": 1, "contributor_confirmed": False},
+        ])
+
+        result = remove_duplicate_phd_candidates(extraction_df)
+
+        self.assertEqual(result["integer_id"].tolist(), [2, 2])
+        self.assertEqual(
+            result["duplicate_phds"].iloc[0],
+            [
+                {"phd_name": "Two", "phd_id": "A2"},
+                {"phd_name": "One", "phd_id": "A1"},
+                {"phd_name": "Three", "phd_id": "A3"},
+            ]
+        )
+        self.assertEqual(
+            result.columns.get_loc("duplicate_phds"),
+            result.columns.get_loc("n_name_search_matches") + 1
+        )
+
+    def test_keeps_first_on_tie(self):
+        extraction_df = pd.DataFrame([
+            {"integer_id": 2, "phd_name": "Two", "phd_id": "A1", "phd_orcid": "O1", "contributor_confirmed": True},
+            {"integer_id": 1, "phd_name": "One", "phd_id": "A1", "phd_orcid": "O1", "contributor_confirmed": True},
+        ])
+
+        result = remove_duplicate_phd_candidates(extraction_df)
+
+        self.assertEqual(result["integer_id"].tolist(), [2])
+        self.assertEqual(
+            result["duplicate_phds"].iloc[0],
+            [
+                {"phd_name": "Two", "phd_id": "A1"},
+                {"phd_name": "One", "phd_id": "A1"},
+            ]
+        )
+
+    def test_uses_openalex_id_as_backup(self):
+        extraction_df = pd.DataFrame([
+            {"integer_id": 1, "phd_name": "One", "phd_id": "A1", "phd_orcid": None, "contributor_confirmed": False},
+            {"integer_id": 2, "phd_name": "Two", "phd_id": "A1", "phd_orcid": None, "contributor_confirmed": True},
+            {"integer_id": 3, "phd_name": "Three", "phd_id": None, "phd_orcid": None, "contributor_confirmed": False},
+        ])
+
+        result = remove_duplicate_phd_candidates(extraction_df)
+
+        self.assertEqual(result["integer_id"].tolist(), [2, 3])
+        self.assertIsNone(result.loc[result["integer_id"] == 3, "duplicate_phds"].iloc[0])
+
+    def test_prefers_orcid_over_openalex_id(self):
+        extraction_df = pd.DataFrame([
+            {"integer_id": 1, "phd_name": "One", "phd_id": "A1", "phd_orcid": "O1", "contributor_confirmed": True},
+            {"integer_id": 2, "phd_name": "Two", "phd_id": "A1", "phd_orcid": "O2", "contributor_confirmed": True},
+        ])
+
+        result = remove_duplicate_phd_candidates(extraction_df)
+
+        self.assertEqual(result["integer_id"].tolist(), [1, 2])
+        self.assertEqual(result["duplicate_phds"].tolist(), [None, None])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_open_alex_match_integration.py
+++ b/tests/test_open_alex_match_integration.py
@@ -1,0 +1,230 @@
+import ast
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from datetime import datetime
+from pathlib import Path
+
+import pandas as pd
+import yaml
+
+# Test how duplicates are handled based on known cases.
+# Run this test like so
+# `$env:RUN_OPENALEX_INTEGRATION="1"; .\.venv\Scripts\python.exe -m unittest tests.test_open_alex_match_integration -v
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+INTEGRATION_IDS = {2127, 99128, 97227, 414, 38061, 43235}
+DUPLICATE_PAIRS = (
+    {2127, 99128},
+    {97227, 414},
+    {38061, 43235}, # Complete duplicate other that institution. Is now removed during data cleaning, so it's not in the cleaned publications anymore
+
+
+@unittest.skipUnless(
+    os.environ.get("RUN_OPENALEX_INTEGRATION") == "1",
+    "Set RUN_OPENALEX_INTEGRATION=1 to run the live OpenAlex integration test.",
+)
+class OpenAlexMatchIntegrationTests(unittest.TestCase):
+    def test_full_script_removes_confirmed_duplicate_candidates(self):
+        project_config = yaml.safe_load(
+            (PROJECT_ROOT / "dataset_config.yaml").read_text(encoding="utf-8")
+        )
+        source_path = Path(project_config["dataset_path"])
+        if not source_path.is_absolute():
+            source_path = PROJECT_ROOT / source_path
+        self.assertTrue(
+            source_path.is_file(),
+            f"Full integration dataset not found: {source_path}",
+        )
+
+        full_input = pd.read_csv(source_path, low_memory=False)
+        filtered_input = full_input[
+            full_input["integer_id"].isin(INTEGRATION_IDS)
+        ].copy()
+        found_ids = set(filtered_input["integer_id"])
+        partially_present_pairs = [
+            pair for pair in DUPLICATE_PAIRS if pair & found_ids and not pair <= found_ids
+        ]
+        self.assertFalse(
+            partially_present_pairs,
+            "The current full dataset contains only one candidate from these "
+            f"duplicate pairs: {partially_present_pairs}",
+        )
+        tested_pairs = tuple(pair for pair in DUPLICATE_PAIRS if pair <= found_ids)
+        self.assertTrue(
+            tested_pairs,
+            "None of the requested duplicate pairs occur in the current full dataset.",
+        )
+        self.assertEqual(len(filtered_input), len(found_ids))
+
+        with tempfile.TemporaryDirectory(
+            prefix="openalex-duplicate-integration-",
+        ) as temporary_directory:
+            test_directory = Path(temporary_directory)
+            input_path = test_directory / "duplicate_candidates.csv"
+            output_path = test_directory / "author_relations.csv"
+            config_path = test_directory / "dataset_config.yaml"
+            filtered_input.to_csv(input_path, index=False)
+
+            config_path.write_text(
+                yaml.safe_dump(
+                    {
+                        "dataset_path": str(input_path),
+                        "dataset_path_sample_gold_standard": None,
+                        "output_filename": str(output_path),
+                        "output_filename_gold_standard": None,
+                        "use_sample_for_gold_standard": False,
+                        "domain": None,
+                        "chunk": None,
+                        "nrows": None,
+                        "min_rank_contrib": None,
+                    },
+                    sort_keys=False,
+                ),
+                encoding="utf-8",
+            )
+
+            pilot_source = PROJECT_ROOT / "data" / "output" / "sups_pilot.csv"
+            if pilot_source.is_file():
+                pilot_target = test_directory / "data" / "output" / "sups_pilot.csv"
+                pilot_target.parent.mkdir(parents=True)
+                shutil.copy2(pilot_source, pilot_target)
+
+            for secret_name in ("contact_email.txt", "openalex_api_key.txt"):
+                secret_source = PROJECT_ROOT / secret_name
+                if secret_source.is_file():
+                    shutil.copy2(secret_source, test_directory / secret_name)
+
+            cache_source = PROJECT_ROOT / "openalex_cache.sqlite"
+            if cache_source.is_file():
+                os.link(cache_source, test_directory / "openalex_cache.sqlite")
+
+            environment = os.environ.copy()
+            environment.update(
+                {
+                    "MPLBACKEND": "Agg",
+                    "OPENALEX_DATASET_CONFIG": str(config_path),
+                    "PYTHONIOENCODING": "utf-8",
+                }
+            )
+            completed = subprocess.run(
+                [sys.executable, str(PROJECT_ROOT / "Open_Alex_Match.py")],
+                cwd=test_directory,
+                env=environment,
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                timeout=1800,
+            )
+
+            artifact_root = Path(
+                os.environ.get(
+                    "OPENALEX_TEST_ARTIFACT_DIR",
+                    PROJECT_ROOT / ".test-artifacts" / "openalex-match",
+                )
+            )
+            run_id = datetime.now().strftime("%Y%m%d-%H%M%S-%f")
+            artifact_directory = artifact_root / run_id
+            artifact_directory.mkdir(parents=True, exist_ok=False)
+
+            if output_path.is_file():
+                shutil.copy2(
+                    output_path,
+                    artifact_directory / "author_relations.csv",
+                )
+            shutil.copy2(
+                config_path,
+                artifact_directory / "dataset_config.yaml",
+            )
+            (artifact_directory / "stdout.txt").write_text(
+                completed.stdout,
+                encoding="utf-8",
+            )
+            (artifact_directory / "stderr.txt").write_text(
+                completed.stderr,
+                encoding="utf-8",
+            )
+            print(f"Integration-test artifacts: {artifact_directory}")
+
+            self.assertEqual(
+                completed.returncode,
+                0,
+                "Open_Alex_Match.py failed.\n"
+                f"STDOUT:\n{completed.stdout}\n"
+                f"STDERR:\n{completed.stderr}",
+            )
+            result = pd.read_csv(output_path)
+            candidate_summary = result.drop_duplicates("integer_id")[
+                [
+                    "integer_id",
+                    "phd_name",
+                    "phd_id",
+                    "phd_orcid",
+                    "phd_match_by",
+                    "duplicate_phds",
+                ]
+            ].to_string(index=False)
+
+            retained_ids = set(result["integer_id"])
+            pairs_with_missing_matches = 0
+
+            for duplicate_pair in tested_pairs:
+                retained_from_pair = retained_ids & duplicate_pair
+                if len(retained_from_pair) == 2:
+                    pair_match_by = result.loc[
+                        result["integer_id"].isin(duplicate_pair),
+                        "phd_match_by",
+                    ]
+                    self.assertTrue(
+                        pair_match_by.isna().any(),
+                        f"Expected pair {sorted(duplicate_pair)} to be deduplicated "
+                        "because neither candidate has a missing phd_match_by value.\n"
+                        f"{candidate_summary}",
+                    )
+                    pairs_with_missing_matches += 1
+                    continue
+
+                self.assertEqual(
+                    len(retained_from_pair),
+                    1,
+                    f"Expected one retained candidate from {sorted(duplicate_pair)}, "
+                    "or both candidates when phd_match_by is missing; "
+                    f"found {sorted(retained_from_pair)}.",
+                )
+                retained_id = retained_from_pair.pop()
+                duplicate_values = (
+                    result.loc[
+                        result["integer_id"] == retained_id,
+                        "duplicate_phds",
+                    ]
+                    .dropna()
+                    .unique()
+                )
+                self.assertEqual(len(duplicate_values), 1)
+                duplicate_metadata = ast.literal_eval(duplicate_values[0])
+                self.assertEqual(len(duplicate_metadata), 2)
+                self.assertTrue(
+                    all(entry["phd_id"] for entry in duplicate_metadata)
+                )
+
+            expected_removed_candidates = len(tested_pairs) - pairs_with_missing_matches
+            expected_candidate_label = (
+                "candidate" if expected_removed_candidates == 1 else "candidates"
+            )
+            self.assertIn(
+                f"Removed {expected_removed_candidates} duplicate PhD "
+                f"{expected_candidate_label}.",
+                completed.stdout,
+                f"Unexpected duplicate-removal count.\n{candidate_summary}",
+            )
+            self.assertEqual(
+                len(retained_ids),
+                len(tested_pairs) + pairs_with_missing_matches,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
- Identify duplicates by Orcid or Open Alex Id.
- Keep the PhD with more confirmed supervisors and the first one if equal
- Add diagnostics column with identified duplicates with the one kept in first place