### PR TITLE
Upgrade OpenAlex API retry and logging logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 
 # logs
 *.log
+*.log.*
 
 # config and settings
 dataset_config.yaml

--- a/Open_Alex_Match.py
+++ b/Open_Alex_Match.py
@@ -25,7 +25,12 @@ from tqdm import tqdm
 from src.unabbreviate_institutions import unabbreviate_institutions
 from src.open_alex_helpers import AuthorRelations, find_phd_and_supervisors_in_row, get_supervisors_openalex_ids
 from src.dataset_config_helpers import read_config, load_dataset
-from src.api_cache_helpers import initialize_request_cache, configure_pyalex_http_timeout
+from src.api_cache_helpers import (
+    OpenAlexDailyLimitError,
+    configure_pyalex_http_timeout,
+    ensure_openalex_budget_available,
+    initialize_request_cache,
+)
 from src.plotters import PhDMatchPlotter, ContributorMatchPlotter
 
 # Initialize tqdm for progress bars
@@ -70,9 +75,27 @@ config.retry_backoff_factor = 1
 configure_pyalex_http_timeout(
     connect_timeout=5,
     read_timeout=20,
-    respect_retry_after=False,
+    respect_retry_after=True,
     max_retry_backoff=10,
 )
+
+# Stop before loading the model or processing rows if OpenAlex cannot accept
+# any new billable requests today. If this lightweight check is unavailable,
+# extraction may continue; runtime 429 handling still protects the output.
+try:
+    rate_limit_status = ensure_openalex_budget_available(config.api_key)
+except OpenAlexDailyLimitError as exc:
+    raise SystemExit(f"Extraction not started: {exc}") from None
+except Exception as exc:
+    print(f"WARNING: OpenAlex budget preflight unavailable: {exc}")
+else:
+    if rate_limit_status:
+        print(
+            "OpenAlex API budget: "
+            f"${rate_limit_status['daily_remaining_usd']} daily and "
+            f"${rate_limit_status['prepaid_remaining_usd']} prepaid remaining; "
+            f"resets at {rate_limit_status['resets_at']}."
+        )
 
 # %% [markdown]
 # ## 2. Load datasets
@@ -186,8 +209,22 @@ model = SentenceTransformer("allenai-specter")
 # set the dict to overwrite the default class attribute specified in src/open_alex_helpers.py
 AuthorRelations.supervisors_in_pilot_dataset = supervisors_in_pilot_dataset
 
+print(
+    r"""
+    ╭──────────────────────────────────────────────╮
+    │  Starting extraction from OpenAlex            │
+    ╰──────────────────────────────────────────────╯
+
+    Listen to the data log:
+    Get-Content .\author_relations.log -Tail 30 -Wait
+
+    Listen to the technical connection log:
+    Get-Content .\extraction.log -Tail 30 -Wait
+    """
+)
 # Process rows explicitly so the progress bar shows which record is active.
 extraction_frames = []
+entries_with_skipped_data = 0
 with tqdm(
     total=len(pubs_high_contrib_df),
     file=sys.stdout,
@@ -201,22 +238,40 @@ with tqdm(
             f"row={row_number}, id={row['integer_id']}, phd={str(row['phd_name'])[:30]}",
             refresh=True,
         )
-        row_result = find_phd_and_supervisors_in_row(row, model)
+        try:
+            row_result = find_phd_and_supervisors_in_row(
+                row,
+                model,
+                row_number=row_number,
+                total_rows=len(pubs_high_contrib_df),
+            )
+        except OpenAlexDailyLimitError as exc:
+            raise SystemExit(
+                "Extraction stopped before writing output: "
+                f"{exc} Completed rows in this run: {row_number - 1}."
+            ) from None
         extraction_frames.append(row_result)
         if row_result["processing_error"].notna().any():
-            tqdm.write(
-                f"OpenAlex request failed for row {row_number} "
-                f"(id={row['integer_id']}, phd={row['phd_name']!r}); "
-                "the row was retained with processing_error set. "
-                "See author_relations.log for details.",
-                file=sys.stdout,
-            )
+            entries_with_skipped_data += 1
         progress.update()
 
 # Concatenate all per-PhD results into one DataFrame.
 extraction_df = pd.concat(extraction_frames, ignore_index=True)
 
 extraction_df.to_csv(output_filename, index=False)
+
+if entries_with_skipped_data:
+    print(
+        f"WARNING: Data was skipped for {entries_with_skipped_data} of "
+        f"{len(pubs_high_contrib_df)} entries because OpenAlex requests "
+        "failed after retries. See author_relations.log for what was skipped "
+        "and extraction.log for technical details."
+    )
+else:
+    print(
+        f"Full extraction completed successfully: all "
+        f"{len(pubs_high_contrib_df)} entries were processed without skipped data."
+    )
 
 extraction_df
 

--- a/Open_Alex_Match.py
+++ b/Open_Alex_Match.py
@@ -25,7 +25,7 @@ from tqdm import tqdm
 from src.unabbreviate_institutions import unabbreviate_institutions
 from src.open_alex_helpers import AuthorRelations, find_phd_and_supervisors_in_row, get_supervisors_openalex_ids
 from src.dataset_config_helpers import read_config, load_dataset
-from src.api_cache_helpers import initialize_request_cache
+from src.api_cache_helpers import initialize_request_cache, configure_pyalex_http_timeout
 from src.plotters import PhDMatchPlotter, ContributorMatchPlotter
 
 # Initialize tqdm for progress bars
@@ -65,8 +65,14 @@ config.api_key = read_secret("openalex_api_key.txt")
 # Pyalex is using [urllib3.util.Retry](https://urllib3.readthedocs.io/en/stable/reference/urllib3.util.html) for retrying.
 
 # %%
-config.max_retries = 7
-config.retry_backoff_factor = 2 # conservative backoff
+config.max_retries = 3
+config.retry_backoff_factor = 1
+configure_pyalex_http_timeout(
+    connect_timeout=5,
+    read_timeout=20,
+    respect_retry_after=False,
+    max_retry_backoff=10,
+)
 
 # %% [markdown]
 # ## 2. Load datasets
@@ -180,14 +186,35 @@ model = SentenceTransformer("allenai-specter")
 # set the dict to overwrite the default class attribute specified in src/open_alex_helpers.py
 AuthorRelations.supervisors_in_pilot_dataset = supervisors_in_pilot_dataset
 
-# Apply the function to each row with a constant, preloaded model
-extraction_series = pubs_high_contrib_df.progress_apply(
-    lambda row: find_phd_and_supervisors_in_row(row, model),
-    axis=1
-    )
+# Process rows explicitly so the progress bar shows which record is active.
+extraction_frames = []
+with tqdm(
+    total=len(pubs_high_contrib_df),
+    file=sys.stdout,
+    ncols=120,
+    miniters=1,
+    desc="Matching",
+    bar_format="{l_bar}{bar}| {n_fmt}/{total_fmt} [{elapsed}<{remaining}, {rate_fmt}] {postfix}",
+) as progress:
+    for row_number, (_, row) in enumerate(pubs_high_contrib_df.iterrows(), start=1):
+        progress.set_postfix_str(
+            f"row={row_number}, id={row['integer_id']}, phd={str(row['phd_name'])[:30]}",
+            refresh=True,
+        )
+        row_result = find_phd_and_supervisors_in_row(row, model)
+        extraction_frames.append(row_result)
+        if row_result["processing_error"].notna().any():
+            tqdm.write(
+                f"OpenAlex request failed for row {row_number} "
+                f"(id={row['integer_id']}, phd={row['phd_name']!r}); "
+                "the row was retained with processing_error set. "
+                "See author_relations.log for details.",
+                file=sys.stdout,
+            )
+        progress.update()
 
-# Concatenate all DataFrames into one
-extraction_df = pd.concat(list(extraction_series), ignore_index=True)
+# Concatenate all per-PhD results into one DataFrame.
+extraction_df = pd.concat(extraction_frames, ignore_index=True)
 
 extraction_df.to_csv(output_filename, index=False)
 

--- a/src/api_cache_helpers.py
+++ b/src/api_cache_helpers.py
@@ -1,4 +1,13 @@
+import logging
+from time import monotonic
+
+import pyalex.api
 import requests_cache
+
+
+_LOGGER = logging.getLogger("openalex.http")
+_ORIGINAL_GET_REQUESTS_SESSION = pyalex.api._get_requests_session
+_PYALEX_SESSION_PATCHED = False
 
 def initialize_request_cache():
     """
@@ -13,4 +22,90 @@ def initialize_request_cache():
         expire_after=requests_cache.NEVER_EXPIRE
 
     )
+
+
+def configure_pyalex_http_timeout(
+    connect_timeout=5,
+    read_timeout=20,
+    respect_retry_after=False,
+    max_retry_backoff=10,
+):
+    """
+    Add finite timeouts, bounded retry delays, and request timing logs to PyAlex.
+
+    PyAlex 0.18 does not pass a timeout to ``requests``. A network request can
+    therefore wait indefinitely. This wrapper retains PyAlex's retry-enabled
+    session while supplying a default timeout to every request it makes.
+
+    urllib3 normally honors a server's ``Retry-After`` header without capping
+    the requested delay. Disabling that behavior makes retries use the bounded
+    exponential backoff configured in PyAlex instead.
+    """
+    global _PYALEX_SESSION_PATCHED
+
+    if _PYALEX_SESSION_PATCHED:
+        return
+
+    timeout = (connect_timeout, read_timeout)
+    policy_logged = False
+
+    def get_requests_session_with_timeout():
+        nonlocal policy_logged
+
+        session = _ORIGINAL_GET_REQUESTS_SESSION()
+
+        # PyAlex mounts an HTTPAdapter containing urllib3's Retry object.
+        # Bound both header-driven and exponential retry sleeps.
+        for adapter in session.adapters.values():
+            retries = getattr(adapter, "max_retries", None)
+            if retries is not None:
+                retries.respect_retry_after_header = respect_retry_after
+                retries.backoff_max = max_retry_backoff
+
+        original_request = session.request
+
+        if not policy_logged:
+            _LOGGER.info(
+                "OpenAlex HTTP policy active: timeout=%s "
+                "respect_retry_after=%s max_retry_backoff=%ss",
+                timeout,
+                respect_retry_after,
+                max_retry_backoff,
+            )
+            policy_logged = True
+
+        def request_with_timeout(method, url, **kwargs):
+            kwargs.setdefault("timeout", timeout)
+            started_at = monotonic()
+            _LOGGER.info(
+                "OpenAlex request started: method=%s url=%s timeout=%s",
+                method,
+                url,
+                timeout,
+            )
+            try:
+                response = original_request(method, url, **kwargs)
+            except Exception:
+                _LOGGER.exception(
+                    "OpenAlex request failed after %.1fs: method=%s url=%s",
+                    monotonic() - started_at,
+                    method,
+                    url,
+                )
+                raise
+
+            _LOGGER.info(
+                "OpenAlex request finished in %.1fs: status=%s cache=%s url=%s",
+                monotonic() - started_at,
+                response.status_code,
+                getattr(response, "from_cache", False),
+                url,
+            )
+            return response
+
+        session.request = request_with_timeout
+        return session
+
+    pyalex.api._get_requests_session = get_requests_session_with_timeout
+    _PYALEX_SESSION_PATCHED = True
 

--- a/src/api_cache_helpers.py
+++ b/src/api_cache_helpers.py
@@ -1,13 +1,123 @@
 import logging
-from time import monotonic
+from time import monotonic, sleep
 
 import pyalex.api
+import requests
 import requests_cache
+from requests.exceptions import RequestException
 
 
 _LOGGER = logging.getLogger("openalex.http")
 _ORIGINAL_GET_REQUESTS_SESSION = pyalex.api._get_requests_session
 _PYALEX_SESSION_PATCHED = False
+
+
+class OpenAlexDailyLimitError(RequestException):
+    """Raised when OpenAlex reports that the daily API budget is exhausted."""
+
+    def __init__(self, reset_seconds=None, response=None):
+        self.reset_seconds = reset_seconds
+        reset_message = (
+            f" It resets in approximately {reset_seconds} seconds."
+            if reset_seconds is not None
+            else ""
+        )
+        super().__init__(
+            "OpenAlex daily API budget exhausted."
+            f"{reset_message} Cached requests remain available, but new API "
+            "queries cannot complete until the budget resets or prepaid "
+            "credit is available.",
+            response=response,
+        )
+
+
+def _number_from_header(headers, name):
+    value = headers.get(name)
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _seconds_from_header(headers, name="X-RateLimit-Reset"):
+    value = _number_from_header(headers, name)
+    return max(0, int(value)) if value is not None else None
+
+
+def _daily_budget_exhausted(response):
+    remaining = _number_from_header(
+        response.headers,
+        "X-RateLimit-Remaining",
+    )
+    if remaining is not None:
+        return remaining <= 0
+
+    # OpenAlex documents rate-limit headers on every response, but retaining a
+    # conservative body fallback keeps quota handling useful through proxies
+    # that strip non-standard headers.
+    body = response.text.lower()
+    return "daily" in body and ("budget" in body or "limit" in body)
+
+
+def get_openalex_rate_limit_status(api_key, timeout=(5, 20)):
+    """Return a fresh, sanitized summary from OpenAlex's rate-limit endpoint."""
+    if not api_key:
+        return None
+
+    try:
+        # The main cache never expires, so this status request must bypass it.
+        with requests_cache.disabled():
+            response = requests.get(
+                "https://api.openalex.org/rate-limit",
+                params={"api_key": api_key},
+                timeout=timeout,
+            )
+    except RequestException:
+        # Do not leak the API key through a Requests exception containing the
+        # fully prepared URL.
+        raise RequestException(
+            "Could not check the current OpenAlex API budget."
+        ) from None
+
+    if not response.ok:
+        raise RequestException(
+            "The OpenAlex rate-limit check returned HTTP "
+            f"{response.status_code}."
+        )
+
+    rate_limit = response.json().get("rate_limit", {})
+    return {
+        "daily_budget_usd": rate_limit.get("daily_budget_usd"),
+        "daily_used_usd": rate_limit.get("daily_used_usd"),
+        "daily_remaining_usd": rate_limit.get("daily_remaining_usd"),
+        "prepaid_remaining_usd": rate_limit.get("prepaid_remaining_usd"),
+        "resets_at": rate_limit.get("resets_at"),
+        "resets_in_seconds": rate_limit.get("resets_in_seconds"),
+        "endpoint_costs_usd": rate_limit.get("endpoint_costs_usd", {}),
+    }
+
+
+def ensure_openalex_budget_available(api_key, timeout=(5, 20)):
+    """Fail before extraction when neither daily nor prepaid budget remains."""
+    status = get_openalex_rate_limit_status(api_key, timeout=timeout)
+    if status is None:
+        return None
+
+    daily_remaining = status.get("daily_remaining_usd")
+    prepaid_remaining = status.get("prepaid_remaining_usd")
+    if (
+        daily_remaining is not None
+        and float(daily_remaining) <= 0
+        and (prepaid_remaining is None or float(prepaid_remaining) <= 0)
+    ):
+        raise OpenAlexDailyLimitError(
+            reset_seconds=status.get("resets_in_seconds")
+        )
+
+    return status
+
 
 def initialize_request_cache():
     """
@@ -27,8 +137,9 @@ def initialize_request_cache():
 def configure_pyalex_http_timeout(
     connect_timeout=5,
     read_timeout=20,
-    respect_retry_after=False,
+    respect_retry_after=True,
     max_retry_backoff=10,
+    max_rate_limit_retries=3,
 ):
     """
     Add finite timeouts, bounded retry delays, and request timing logs to PyAlex.
@@ -37,9 +148,8 @@ def configure_pyalex_http_timeout(
     therefore wait indefinitely. This wrapper retains PyAlex's retry-enabled
     session while supplying a default timeout to every request it makes.
 
-    urllib3 normally honors a server's ``Retry-After`` header without capping
-    the requested delay. Disabling that behavior makes retries use the bounded
-    exponential backoff configured in PyAlex instead.
+    HTTP 429 responses are handled separately so daily-budget exhaustion can
+    stop immediately, while short-lived rate limits use bounded retries.
     """
     global _PYALEX_SESSION_PATCHED
 
@@ -59,18 +169,29 @@ def configure_pyalex_http_timeout(
         for adapter in session.adapters.values():
             retries = getattr(adapter, "max_retries", None)
             if retries is not None:
-                retries.respect_retry_after_header = respect_retry_after
+                # urllib3 does not cap Retry-After sleeps. The wrapper handles
+                # 429 Retry-After values itself below with max_retry_backoff.
+                retries.respect_retry_after_header = False
                 retries.backoff_max = max_retry_backoff
+                # Let the wrapper below inspect 429 quota headers before any
+                # retry. The adapter continues to retry PyAlex's 5xx codes.
+                retries.status_forcelist = {
+                    status
+                    for status in retries.status_forcelist
+                    if status != 429
+                }
 
         original_request = session.request
 
         if not policy_logged:
             _LOGGER.info(
                 "OpenAlex HTTP policy active: timeout=%s "
-                "respect_retry_after=%s max_retry_backoff=%ss",
+                "respect_retry_after=%s max_retry_backoff=%ss "
+                "max_rate_limit_retries=%s",
                 timeout,
                 respect_retry_after,
                 max_retry_backoff,
+                max_rate_limit_retries,
             )
             policy_logged = True
 
@@ -84,7 +205,53 @@ def configure_pyalex_http_timeout(
                 timeout,
             )
             try:
-                response = original_request(method, url, **kwargs)
+                rate_limit_attempt = 0
+                while True:
+                    response = original_request(method, url, **kwargs)
+                    if response.status_code != 429:
+                        break
+
+                    reset_seconds = _seconds_from_header(response.headers)
+                    if _daily_budget_exhausted(response):
+                        _LOGGER.error(
+                            "OpenAlex daily API budget exhausted: "
+                            "remaining=%s reset_seconds=%s",
+                            response.headers.get("X-RateLimit-Remaining"),
+                            reset_seconds,
+                        )
+                        raise OpenAlexDailyLimitError(
+                            reset_seconds=reset_seconds,
+                            response=response,
+                        )
+
+                    if rate_limit_attempt >= max_rate_limit_retries:
+                        response.raise_for_status()
+
+                    retry_after = _seconds_from_header(
+                        response.headers,
+                        "Retry-After",
+                    )
+                    exponential_delay = min(
+                        max_retry_backoff,
+                        2 ** rate_limit_attempt,
+                    )
+                    delay = (
+                        min(retry_after, max_retry_backoff)
+                        if respect_retry_after and retry_after is not None
+                        else exponential_delay
+                    )
+                    rate_limit_attempt += 1
+                    _LOGGER.warning(
+                        "OpenAlex returned a transient HTTP 429; retrying "
+                        "in %ss (attempt %s/%s, remaining=%s)",
+                        delay,
+                        rate_limit_attempt,
+                        max_rate_limit_retries,
+                        response.headers.get("X-RateLimit-Remaining"),
+                    )
+                    sleep(delay)
+            except OpenAlexDailyLimitError:
+                raise
             except Exception:
                 _LOGGER.exception(
                     "OpenAlex request failed after %.1fs: method=%s url=%s",
@@ -94,11 +261,23 @@ def configure_pyalex_http_timeout(
                 )
                 raise
 
+            from_cache = getattr(response, "from_cache", False)
             _LOGGER.info(
-                "OpenAlex request finished in %.1fs: status=%s cache=%s",
+                "OpenAlex request finished in %.1fs: status=%s cache=%s "
+                "daily_remaining=%s reset_seconds=%s",
                 monotonic() - started_at,
                 response.status_code,
-                getattr(response, "from_cache", False),
+                from_cache,
+                (
+                    "cached"
+                    if from_cache
+                    else response.headers.get("X-RateLimit-Remaining")
+                ),
+                (
+                    "cached"
+                    if from_cache
+                    else response.headers.get("X-RateLimit-Reset")
+                ),
             )
             return response
 

--- a/src/api_cache_helpers.py
+++ b/src/api_cache_helpers.py
@@ -95,11 +95,10 @@ def configure_pyalex_http_timeout(
                 raise
 
             _LOGGER.info(
-                "OpenAlex request finished in %.1fs: status=%s cache=%s url=%s",
+                "OpenAlex request finished in %.1fs: status=%s cache=%s",
                 monotonic() - started_at,
                 response.status_code,
                 getattr(response, "from_cache", False),
-                url,
             )
             return response
 

--- a/src/open_alex_helpers.py
+++ b/src/open_alex_helpers.py
@@ -1,16 +1,60 @@
 import logging
+from contextvars import ContextVar
+from datetime import datetime
 from logging.handlers import RotatingFileHandler
+from os import getpid, path, makedirs
 from time import monotonic
 
 from pyalex import Authors, Works, config
 import pandas as pd
 import numpy as np
 from requests.exceptions import RequestException
-from os import path, makedirs
 from sentence_transformers import util
 
+from src.api_cache_helpers import OpenAlexDailyLimitError
 from src.io_helpers import fetch_supervisors_from_pilot_dataset, remove_illegal_title_characters
 from src.clean_names_helpers import format_name_to_firstname_lastname, name_sanity_check
+
+
+_RUN_ID = f"{datetime.now():%Y%m%d-%H%M%S}-pid{getpid()}"
+_CURRENT_RECORD = ContextVar(
+    "openalex_record",
+    default={
+        "completed_rows": "-",
+        "row_number": "-",
+        "total_rows": "-",
+        "record_id": "-",
+    },
+)
+
+
+class _ExtractionContextFilter(logging.Filter):
+    """Add shared correlation fields to every technical and progress entry."""
+
+    def filter(self, record):
+        record_context = _CURRENT_RECORD.get()
+        record.run_id = _RUN_ID
+        record.completed_rows = record_context["completed_rows"]
+        record.row_number = record_context["row_number"]
+        record.total_rows = record_context["total_rows"]
+        record.record_id = record_context["record_id"]
+        return True
+
+
+class _NonTechnicalContentFilter(logging.Filter):
+    """Keep domain-level search and matching content out of technical noise."""
+
+    _TECHNICAL_MESSAGE_PREFIXES = (
+        "ROW START:",
+        "ROW END:",
+        "ROW NETWORK ERROR:",
+    )
+
+    def filter(self, record):
+        return not record.getMessage().startswith(
+            self._TECHNICAL_MESSAGE_PREFIXES
+        )
+
 
 class AuthorRelations:
     # Class attribute shared by all instances
@@ -18,9 +62,11 @@ class AuthorRelations:
     # Keys: supervisor name 
     # Values: supervisor OpenAlex ID
     supervisors_in_pilot_dataset = dict()
-    _log_handler = None
+    _technical_log_handler = None
+    _nontechnical_log_handler = None
+    _run_started_logged = False
     
-    def __init__(self, integer_id, phd_name, title, year, institution, contributors, model, years_tolerance=0, verbosity='DEBUG'):
+    def __init__(self, integer_id, phd_name, title, year, institution, contributors, model, years_tolerance=0):
         self.integer_id = integer_id
         self.phd_name = phd_name
         self.n_name_search_matches = None # Number of matches for the PhD candidate's name between NARCIS and OpenAlex
@@ -43,6 +89,10 @@ class AuthorRelations:
         self.phd_match_by = None
         self.potential_supervisors = []
         self.processing_error = None
+        self.progress_step = 0
+        self.current_progress_event = None
+        self.active_contributor_name = None
+        self.active_contributor_rank = None
         
         # NLP model
         self.model = model
@@ -63,10 +113,9 @@ class AuthorRelations:
         # Minimum number of shared publications required for a contributor match 
         self.n_shared_pubs_min = 1
         
-        self.verbosity = verbosity.upper()
-        
         # Setup logging
         self.logger = logging.getLogger(__name__)
+        self.progress_logger = logging.getLogger("extraction.progress")
         self.setup_logging()
 
     def calculate_affiliation_target_years(self):
@@ -83,32 +132,57 @@ class AuthorRelations:
             return set(range(self.year + self.years_tolerance, self.year + 1))
         
     def setup_logging(self):
-        verbosity_levels = {
-            "NONE": logging.WARNING,
-            "INFO": logging.INFO,
-            "DEBUG": logging.DEBUG,
-        }
-
-        log_level = verbosity_levels.get(self.verbosity, logging.INFO)
-
-        formatter = logging.Formatter(
-            "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+        technical_formatter = logging.Formatter(
+            "%(asctime)s - run=%(run_id)s - "
+            "progress=%(completed_rows)s/%(total_rows)s - "
+            "active_row=%(row_number)s/%(total_rows)s - id=%(record_id)s - "
+            "%(name)s - %(levelname)s - %(message)s"
         )
+        # This is the original author-relations log format. The handler below
+        # receives only the semantic search and matching trace, while request,
+        # retry, timing, and correlation diagnostics stay in extraction.log.
+        nontechnical_formatter = logging.Formatter(
+            "%(asctime)s - %(message)s"
+        )
+        context_filter = _ExtractionContextFilter()
 
-        if self.__class__._log_handler is None:
-            file_handler = RotatingFileHandler(
+        if self.__class__._technical_log_handler is None:
+            technical_handler = RotatingFileHandler(
+                "extraction.log",
+                maxBytes=20 * 1024 * 1024,
+                backupCount=3,
+                encoding="utf-8",
+            )
+            technical_handler.setFormatter(technical_formatter)
+            technical_handler.addFilter(context_filter)
+            technical_handler._author_relations_handler = True
+            self.__class__._technical_log_handler = technical_handler
+
+            nontechnical_handler = RotatingFileHandler(
                 "author_relations.log",
                 maxBytes=20 * 1024 * 1024,
                 backupCount=3,
                 encoding="utf-8",
             )
-            file_handler.setFormatter(formatter)
-            file_handler._author_relations_handler = True
-            self.__class__._log_handler = file_handler
-        else:
-            file_handler = self.__class__._log_handler
+            nontechnical_handler.setLevel(logging.DEBUG)
+            nontechnical_handler.setFormatter(nontechnical_formatter)
+            nontechnical_handler.addFilter(_NonTechnicalContentFilter())
+            nontechnical_handler._author_relations_content_handler = True
+            self.__class__._nontechnical_log_handler = nontechnical_handler
 
-        file_handler.setLevel(log_level)
+            # Start each run in clean active files while preserving previous
+            # runs in the normal numbered rotation backups. This also moves
+            # the legacy technical author_relations.log out of the active
+            # human-readable file on the first run after the rename.
+            for handler in (technical_handler, nontechnical_handler):
+                if path.exists(handler.baseFilename) and path.getsize(handler.baseFilename):
+                    handler.doRollover()
+        else:
+            technical_handler = self.__class__._technical_log_handler
+            nontechnical_handler = self.__class__._nontechnical_log_handler
+
+        technical_handler.setLevel(logging.DEBUG)
+        nontechnical_handler.setLevel(logging.DEBUG)
 
         def apply_logger_file_policy(
             name,
@@ -137,35 +211,62 @@ class AuthorRelations:
         # Custom logger with matching diagnostics
         self.logger = apply_logger_file_policy(
             __name__,
-            level=log_level,
-            file_handler=file_handler,
+            level=logging.DEBUG,
+            file_handler=technical_handler,
         )
+        if nontechnical_handler not in self.logger.handlers:
+            self.logger.addHandler(nontechnical_handler)
 
         # PyAlex messages (if any)
         apply_logger_file_policy(
             "pyalex",
-            level=log_level,
-            file_handler=file_handler,
+            level=logging.DEBUG,
+            file_handler=technical_handler,
         )
 
         # urllib3 retry diagnostics
         apply_logger_file_policy(
             "urllib3.util.retry",
-            level=log_level,
-            file_handler=file_handler,
+            level=logging.DEBUG,
+            file_handler=technical_handler,
         )
 
         # Timed start/end/failure messages for each OpenAlex request.
         apply_logger_file_policy(
             "openalex.http",
             level=logging.INFO,
-            file_handler=file_handler,
+            file_handler=technical_handler,
+        )
+
+        # Synthetic progress/correlation messages are technical diagnostics.
+        self.progress_logger = apply_logger_file_policy(
+            "extraction.progress",
+            level=logging.INFO,
+            file_handler=technical_handler,
         )
 
         # Suppress normal successful HTTP request chatter.
         apply_logger_file_policy(
             "urllib3.connectionpool",
             enabled=False,
+        )
+
+        if not self.__class__._run_started_logged:
+            self.progress_logger.info(
+                "step=-- | RUN START | Detailed diagnostics: extraction.log; "
+                "match entries using run, active row, id, and step."
+            )
+            self.__class__._run_started_logged = True
+
+    def log_progress(self, event, message):
+        """Write one correlated, human-readable step to both log files."""
+        self.progress_step += 1
+        self.current_progress_event = event
+        self.progress_logger.info(
+            "step=%02d | %s | %s",
+            self.progress_step,
+            event,
+            message,
         )
 
     def search_phd_candidate(self):
@@ -177,7 +278,7 @@ class AuthorRelations:
             match_score = n_close_matches + (50 if exact_match) + (20 if near_exact_match) + (20 if affiliation_match)
         Then we pick the candidate with the highest match_score.
 
-        If in debug mode, print a table representation of the sorted DataFrame.
+        Log a table representation of the sorted DataFrame.
         """
         self.logger.info(f"Searching for PhD candidate: {self.phd_name}")
         
@@ -290,14 +391,11 @@ class AuthorRelations:
         )
 
 
-        # If logger is in debug mode, print the ranked table
-        if self.logger.isEnabledFor(logging.DEBUG):
-            # Select the columns most relevant for debugging the ranking
-            columns_to_show = [
-                'candidate_name', 'candidate_id', 'candidate_orcid', 'match_score',
-                'max_similarity', 'n_close_matches', 'exact_match', 'near_exact_match', 'affiliation_match'
-            ]
-            self.logger.debug(f"Ranked candidates:\n{candidates_info_with_scores[columns_to_show].to_string(index=False)}")
+        columns_to_show = [
+            'candidate_name', 'candidate_id', 'candidate_orcid', 'match_score',
+            'max_similarity', 'n_close_matches', 'exact_match', 'near_exact_match', 'affiliation_match'
+        ]
+        self.logger.debug(f"Ranked candidates:\n{candidates_info_with_scores[columns_to_show].to_string(index=False)}")
 
         # Select the row of the best candidate (highest match_score) and convert that to dict
         best_candidate_info = candidates_info_with_scores.iloc[0].to_dict()
@@ -351,8 +449,7 @@ class AuthorRelations:
         affiliations = candidate.get('affiliations', [])
         match_found = False
 
-        if self.verbosity == 'DEBUG':
-            self.logger.debug(f"Target Institution: '{self.institution}', Target Years: {self.affiliation_target_years}")
+        self.logger.debug(f"Target Institution: '{self.institution}', Target Years: {self.affiliation_target_years}")
 
         for affiliation in affiliations:
             institution_name = affiliation['institution']['display_name']
@@ -465,6 +562,10 @@ class AuthorRelations:
                 "PhD candidate not confirmed. Cannot find potential supervisors; "
                 "recording contributors only with NARCIS data."
             )
+            self.log_progress(
+                "SUPERVISOR CHECK SKIPPED",
+                "The PhD candidate was not confirmed; contributor names were retained.",
+            )
 
             for idx, contributor_name in enumerate(self.contributors):
                 contributor_rank = idx + 1
@@ -484,6 +585,10 @@ class AuthorRelations:
             self.logger.warning(
                 "PhD candidate has no affiliations in target years. Cannot find potential supervisors; "
                 "recording contributors only with NARCIS data."
+            )
+            self.log_progress(
+                "SUPERVISOR CHECK SKIPPED",
+                "No affiliation was found around graduation; contributor names were retained.",
             )
 
             for idx, contributor_name in enumerate(self.contributors):
@@ -506,7 +611,13 @@ class AuthorRelations:
 
         for idx, contributor_name in enumerate(self.contributors):
             contributor_rank = idx + 1
+            self.active_contributor_name = contributor_name
+            self.active_contributor_rank = contributor_rank
             self.logger.debug(f"Processing contributor #{contributor_rank}: {contributor_name}")
+            self.log_progress(
+                "CONTRIBUTOR START",
+                f"{contributor_rank}/{len(self.contributors)} | name={contributor_name!r}",
+            )
 
             # Search for contributors in OpenAlex
             openalex_candidates = Authors().search(contributor_name).get()
@@ -526,6 +637,11 @@ class AuthorRelations:
                     f"No OpenAlex matches for '{contributor_name}'. Adding placeholder entry."
                 )
                 self.potential_supervisors.append(supervisor_data)
+                self.log_progress(
+                    "CONTRIBUTOR END",
+                    f"{contributor_rank}/{len(self.contributors)} | "
+                    f"name={contributor_name!r} | supervisor confirmed=no",
+                )
                 continue
 
             # Identify candidates with either shared institution or shared publications
@@ -628,6 +744,12 @@ class AuthorRelations:
                 
             # Append the data before moving to the next supervisor listed in NARCIS
             self.potential_supervisors.append(supervisor_data)
+            self.log_progress(
+                "CONTRIBUTOR END",
+                f"{contributor_rank}/{len(self.contributors)} | "
+                f"name={contributor_name!r} | "
+                f"supervisor confirmed={'yes' if criteria_met else 'no'}",
+            )
 
         self.logger.info(
             f"Processed {len(self.contributors)} contributors; "
@@ -887,7 +1009,12 @@ def compute_and_sort_works_by_title_similarities(works: pd.DataFrame, reference_
     return works
 
 
-def find_phd_and_supervisors_in_row(row, model):
+def find_phd_and_supervisors_in_row(
+    row,
+    model,
+    row_number=None,
+    total_rows=None,
+):
     """
     Finds author relations information from a DataFrame row.
 
@@ -908,56 +1035,179 @@ def find_phd_and_supervisors_in_row(row, model):
     institution = row['institution']
     contributors = [row[f'contributor_{i}'] for i in range(1, 11) if pd.notna(row.get(f'contributor_{i}', None))]
     
-    # Create an instance of AuthorRelations
-    author_relations = AuthorRelations(
-        integer_id=integer_id,
-        phd_name=phd_name,
-        title=title,
-        year=year,
-        institution=institution,
-        contributors=contributors,
-        model=model,
-        years_tolerance=-4, # cf. issue #19
-        verbosity='DEBUG'  # Set to 'NONE' for production
+    record_context_token = _CURRENT_RECORD.set(
+        {
+            "completed_rows": (
+                row_number - 1
+                if isinstance(row_number, int)
+                else "-"
+            ),
+            "row_number": row_number if row_number is not None else "-",
+            "total_rows": total_rows if total_rows is not None else "-",
+            "record_id": integer_id,
+        }
     )
-    
-    started_at = monotonic()
-    author_relations.logger.info(
-        "ROW START: integer_id=%s phd_name=%r year=%s contributors=%s",
-        integer_id,
-        phd_name,
-        year,
-        len(contributors),
-    )
-
     try:
-        # Search for the PhD candidate
-        author_relations.search_phd_candidate()
+        # Create an instance of AuthorRelations.
+        author_relations = AuthorRelations(
+            integer_id=integer_id,
+            phd_name=phd_name,
+            title=title,
+            year=year,
+            institution=institution,
+            contributors=contributors,
+            model=model,
+            years_tolerance=-4, # cf. issue #19
+        )
 
-        # Find potential supervisors among the contributors
-        author_relations.collect_supervision_metadata()
-    except RequestException as exc:
-        # Preserve the row and continue with the dataset after bounded retries
-        # are exhausted. The output makes incomplete records explicit.
-        author_relations.processing_error = f"{type(exc).__name__}: {exc}"
-        author_relations.logger.exception(
-            "ROW NETWORK ERROR: integer_id=%s phd_name=%r",
+        started_at = monotonic()
+        author_relations.log_progress(
+            "RECORD START",
+            f"PhD={phd_name!r} | year={year} | "
+            f"listed contributors={len(contributors)}",
+        )
+        author_relations.logger.info(
+            "ROW START: integer_id=%s phd_name=%r year=%s contributors=%s",
             integer_id,
             phd_name,
+            year,
+            len(contributors),
         )
-    
-    # Get the DataFrame results
-    results_df = author_relations.get_results()
 
-    author_relations.logger.info(
-        "ROW END: integer_id=%s phd_name=%r elapsed=%.1fs error=%s",
-        integer_id,
-        phd_name,
-        monotonic() - started_at,
-        author_relations.processing_error is not None,
-    )
-    
-    return results_df
+        try:
+            author_relations.log_progress(
+                "PHD SEARCH START",
+                f"Searching for PhD candidate {phd_name!r}.",
+            )
+            author_relations.search_phd_candidate()
+            matched_phd_name = (
+                author_relations.phd_candidate["display_name"]
+                if author_relations.phd_candidate
+                else None
+            )
+            author_relations.log_progress(
+                "PHD SEARCH END",
+                (
+                    f"Candidate confirmed=yes | matched name={matched_phd_name!r}"
+                    if author_relations.phd_match_by
+                    else "Candidate confirmed=no"
+                ),
+            )
+
+            author_relations.log_progress(
+                "SUPERVISOR CHECK START",
+                f"Checking {len(contributors)} listed contributor(s).",
+            )
+            author_relations.collect_supervision_metadata()
+            confirmed_supervisors = sum(
+                1
+                for supervisor in author_relations.potential_supervisors
+                if supervisor["supervisor_confirmed"]
+            )
+            author_relations.log_progress(
+                "SUPERVISOR CHECK END",
+                f"Confirmed supervisors={confirmed_supervisors}.",
+            )
+        except OpenAlexDailyLimitError:
+            # A daily quota cannot recover on the next row. Let the top-level
+            # extraction stop before it writes a plausible-looking but
+            # incomplete output dataset.
+            raise
+        except RequestException as exc:
+            # Preserve the row and continue with the dataset after bounded
+            # retries are exhausted. Technical details stay out of the
+            # human-readable progress log.
+            author_relations.processing_error = f"{type(exc).__name__}: {exc}"
+
+            error_type = type(exc).__name__
+            if author_relations.current_progress_event == "PHD SEARCH START":
+                skipped_content_message = (
+                    "The OpenAlex request did not complete after retries during the PhD "
+                    f"candidate search. Skipped PhD matching and all "
+                    f"{len(contributors)} listed contributor checks for this "
+                    "record; a placeholder or partial record was retained."
+                )
+                skipped_data_message = (
+                    f"OpenAlex API error after retries ({error_type}) during the "
+                    f"PhD candidate search. PhD matching and all listed "
+                    f"contributor checks ({len(contributors)}) for this record "
+                    "were skipped; a placeholder or partial record was retained."
+                )
+            elif author_relations.active_contributor_rank is not None:
+                contributor_rank = author_relations.active_contributor_rank
+                later_contributors = len(contributors) - contributor_rank
+                if later_contributors:
+                    contributor_label = (
+                        "contributor"
+                        if later_contributors == 1
+                        else "contributors"
+                    )
+                    skipped_contributors = (
+                        f"Data for this contributor and the {later_contributors} "
+                        f"later {contributor_label} was skipped"
+                    )
+                else:
+                    skipped_contributors = "Data for this contributor was skipped"
+                skipped_content_message = (
+                    "The OpenAlex request did not complete after retries while checking "
+                    f"contributor {contributor_rank}/{len(contributors)} "
+                    f"{author_relations.active_contributor_name!r}. "
+                    f"{skipped_contributors}; already completed data for this "
+                    "record was retained."
+                )
+                skipped_data_message = (
+                    f"OpenAlex API error after retries ({error_type}) while "
+                    f"checking contributor {contributor_rank}/{len(contributors)} "
+                    f"{author_relations.active_contributor_name!r}. "
+                    f"{skipped_contributors}; already completed data for this "
+                    "record was retained."
+                )
+            else:
+                skipped_content_message = (
+                    "The OpenAlex request did not complete after retries during supervisor "
+                    "checking. Skipped unfinished supervisor data; already "
+                    "completed data for this record was retained."
+                )
+                skipped_data_message = (
+                    f"OpenAlex API error after retries ({error_type}) during "
+                    "supervisor checking. Unfinished supervisor data was skipped; "
+                    "already completed data for this record was retained."
+                )
+
+            author_relations.logger.warning(skipped_content_message)
+            author_relations.log_progress(
+                "NETWORK ERROR",
+                skipped_data_message,
+            )
+            author_relations.logger.exception(
+                "ROW NETWORK ERROR: integer_id=%s phd_name=%r",
+                integer_id,
+                phd_name,
+            )
+
+        # Get the DataFrame results.
+        results_df = author_relations.get_results()
+        elapsed = monotonic() - started_at
+        status = (
+            "completed with network error"
+            if author_relations.processing_error
+            else "completed"
+        )
+        author_relations.log_progress(
+            "RECORD END",
+            f"PhD={phd_name!r} | status={status} | elapsed={elapsed:.1f}s",
+        )
+        author_relations.logger.info(
+            "ROW END: integer_id=%s phd_name=%r elapsed=%.1fs error=%s",
+            integer_id,
+            phd_name,
+            elapsed,
+            author_relations.processing_error is not None,
+        )
+
+        return results_df
+    finally:
+        _CURRENT_RECORD.reset(record_context_token)
     
 
 def fetch_author_openalex_names_ids(author: str) -> dict[str, str]:

--- a/src/open_alex_helpers.py
+++ b/src/open_alex_helpers.py
@@ -1,7 +1,11 @@
 import logging
+from logging.handlers import RotatingFileHandler
+from time import monotonic
+
 from pyalex import Authors, Works, config
 import pandas as pd
 import numpy as np
+from requests.exceptions import RequestException
 from os import path, makedirs
 from sentence_transformers import util
 
@@ -14,6 +18,7 @@ class AuthorRelations:
     # Keys: supervisor name 
     # Values: supervisor OpenAlex ID
     supervisors_in_pilot_dataset = dict()
+    _log_handler = None
     
     def __init__(self, integer_id, phd_name, title, year, institution, contributors, model, years_tolerance=0, verbosity='DEBUG'):
         self.integer_id = integer_id
@@ -37,6 +42,7 @@ class AuthorRelations:
         self.phd_candidate = None
         self.phd_match_by = None
         self.potential_supervisors = []
+        self.processing_error = None
         
         # NLP model
         self.model = model
@@ -89,9 +95,20 @@ class AuthorRelations:
             "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
         )
 
-        file_handler = logging.FileHandler("author_relations.log", encoding="utf-8")
+        if self.__class__._log_handler is None:
+            file_handler = RotatingFileHandler(
+                "author_relations.log",
+                maxBytes=20 * 1024 * 1024,
+                backupCount=3,
+                encoding="utf-8",
+            )
+            file_handler.setFormatter(formatter)
+            file_handler._author_relations_handler = True
+            self.__class__._log_handler = file_handler
+        else:
+            file_handler = self.__class__._log_handler
+
         file_handler.setLevel(log_level)
-        file_handler.setFormatter(formatter)
 
         def apply_logger_file_policy(
             name,
@@ -103,8 +120,6 @@ class AuthorRelations:
         ):
             logger = logging.getLogger(name)
 
-            logger.handlers.clear()
-
             logger.propagate = propagate
             logger.disabled = not enabled
 
@@ -114,7 +129,7 @@ class AuthorRelations:
             if level is not None:
                 logger.setLevel(level)
 
-            if file_handler is not None:
+            if file_handler is not None and file_handler not in logger.handlers:
                 logger.addHandler(file_handler)
 
             return logger
@@ -140,7 +155,14 @@ class AuthorRelations:
             file_handler=file_handler,
         )
 
-        # Suppress normal successful HTTP request chatter by suppressing everything below WARNING
+        # Timed start/end/failure messages for each OpenAlex request.
+        apply_logger_file_policy(
+            "openalex.http",
+            level=logging.INFO,
+            file_handler=file_handler,
+        )
+
+        # Suppress normal successful HTTP request chatter.
         apply_logger_file_policy(
             "urllib3.connectionpool",
             enabled=False,
@@ -656,7 +678,8 @@ class AuthorRelations:
             'is_sup_in_pilot_dataset', 
             'n_shared_pubs', 
             'shared_pubs', 
-            'is_thesis_coauthor'
+            'is_thesis_coauthor',
+            'processing_error',
         ]
 
         integer_id = self.integer_id
@@ -717,12 +740,16 @@ class AuthorRelations:
                 'is_sup_in_pilot_dataset': is_sup_in_pilot_dataset,
                 'n_shared_pubs': len(shared_pubs),
                 'shared_pubs': shared_pubs,
-                'is_thesis_coauthor': is_thesis_coauthor
+                'is_thesis_coauthor': is_thesis_coauthor,
+                'processing_error': self.processing_error,
             }
             results_list.append(result_row)
         
         if not results_list:
-            self.logger.warning("PhD candidate confirmed, but no supervisors found.")
+            if self.phd_candidate:
+                self.logger.warning("PhD candidate confirmed, but no supervisors found.")
+            else:
+                self.logger.warning("No confirmed PhD candidate or supervisors found.")
             # Create a single row with the data we have and the others as None
             result_row = {col: None for col in columns}
             result_row['integer_id'] = integer_id
@@ -741,6 +768,7 @@ class AuthorRelations:
             result_row['affiliation_match'] = self.affiliation_match
             result_row['phd_match_score'] = self.phd_match_score
             result_row['phd_match_by'] = self.phd_match_by
+            result_row['processing_error'] = self.processing_error
             # The supervisor-related columns remain None
             results_df = pd.DataFrame([result_row], columns=columns)
         else:
@@ -893,14 +921,41 @@ def find_phd_and_supervisors_in_row(row, model):
         verbosity='DEBUG'  # Set to 'NONE' for production
     )
     
-    # Search for the PhD candidate
-    author_relations.search_phd_candidate()
-    
-    # Find potential supervisors among the contributors
-    author_relations.collect_supervision_metadata()
+    started_at = monotonic()
+    author_relations.logger.info(
+        "ROW START: integer_id=%s phd_name=%r year=%s contributors=%s",
+        integer_id,
+        phd_name,
+        year,
+        len(contributors),
+    )
+
+    try:
+        # Search for the PhD candidate
+        author_relations.search_phd_candidate()
+
+        # Find potential supervisors among the contributors
+        author_relations.collect_supervision_metadata()
+    except RequestException as exc:
+        # Preserve the row and continue with the dataset after bounded retries
+        # are exhausted. The output makes incomplete records explicit.
+        author_relations.processing_error = f"{type(exc).__name__}: {exc}"
+        author_relations.logger.exception(
+            "ROW NETWORK ERROR: integer_id=%s phd_name=%r",
+            integer_id,
+            phd_name,
+        )
     
     # Get the DataFrame results
     results_df = author_relations.get_results()
+
+    author_relations.logger.info(
+        "ROW END: integer_id=%s phd_name=%r elapsed=%.1fs error=%s",
+        integer_id,
+        phd_name,
+        monotonic() - started_at,
+        author_relations.processing_error is not None,
+    )
     
     return results_df
     


### PR DESCRIPTION
- Added 5-second connect and 20-second read timeouts.
- Reduced retries to three with shorter backoff.
- Failed requests now mark only that row with processing_error; processing continues.
- Progress now shows the active row, ID, and PhD name.
- Added request and row timing to [author_relations.log](C:/Projects/clean-and-enrich-phd-supervisor-data/author_relations.log).
- Logs now rotate instead of growing indefinitely.

Watch log in real time in separate terminal with

```bash
Get-Content .\author_relations.log -Tail 30 -Wait
```